### PR TITLE
Add distDir to defaultConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ module.exports = {
             files = files || [];
 
             return {
-              distDir: distDir,
               distFiles: files
             };
           })

--- a/index.js
+++ b/index.js
@@ -14,33 +14,43 @@ module.exports = {
       name: options.name,
       defaultConfig: {
         environment: 'production',
-        outputPath: 'tmp' + path.sep + 'deploy-dist'
+        outputPath: 'tmp' + path.sep + 'deploy-dist',
+        distDir: function(context) {
+          return context.distDir;
+        }
       },
 
-      build: function(context) {
-        var self       = this;
+      setup: function() {
         var outputPath = this.readConfig('outputPath');
+        return {
+          distDir: outputPath
+        };
+      },
+
+      build: function(/* context */) {
+        var self       = this;
+        var distDir    = this.readConfig('distDir');
         var buildEnv   = this.readConfig('environment');
 
         var Builder  = this.project.require('ember-cli/lib/models/builder');
         var builder = new Builder({
           ui: this.ui,
-          outputPath: outputPath,
+          outputPath: distDir,
           environment: buildEnv,
           project: this.project
         });
 
-        this.log('building app to `' + outputPath + '` using buildEnv `' + buildEnv + '`...', { verbose: true });
+        this.log('building app to `' + distDir + '` using buildEnv `' + buildEnv + '`...', { verbose: true });
         return builder.build()
           .finally(function() {
             return builder.cleanup();
           })
-          .then(this._logSuccess.bind(this, outputPath))
+          .then(this._logSuccess.bind(this, distDir))
           .then(function(files) {
             files = files || [];
 
             return {
-              distDir: outputPath,
+              distDir: distDir,
               distFiles: files
             };
           })

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -76,7 +76,9 @@ describe('build plugin', function() {
           build: {
             environment: 'development',
             outputPath: 'tmp/dist-deploy',
-            distDir: 'tmp/dist-deploy'
+            distDir: function(context) {
+              return context.distDir;
+            }
           }
         };
         plugin = subject.createDeployPlugin({

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -60,8 +60,7 @@ describe('build plugin', function() {
 
           return previous;
         }, []);
-
-        assert.equal(messages.length, 2);
+        assert.equal(messages.length, 3);
       });
 
       it('adds default config to the config object', function() {
@@ -76,7 +75,8 @@ describe('build plugin', function() {
         config = {
           build: {
             environment: 'development',
-            outputPath: 'tmp/dist-deploy'
+            outputPath: 'tmp/dist-deploy',
+            distDir: 'tmp/dist-deploy'
           }
         };
         plugin = subject.createDeployPlugin({
@@ -102,6 +102,39 @@ describe('build plugin', function() {
     });
   });
 
+  describe('setup hook', function() {
+    var plugin, context;
+
+    beforeEach(function() {
+      plugin = subject.createDeployPlugin({
+        name: 'build'
+      });
+
+      context = {
+        ui: mockUi,
+        project: {
+          name: function() { return 'test-project'; },
+          require: function(mod) { return require(mod); },
+          addons: [],
+          root: 'tests/dummy'
+        },
+        config: {
+          build: {
+            buildEnv: 'development',
+            outputPath: 'tmp/dist-deploy'
+          }
+        }
+      };
+      plugin.beforeHook(context);
+    });
+    
+    it('resolves with distDir', function() {
+      assert.deepEqual(plugin.setup(context), {
+        distDir: 'tmp/dist-deploy'
+      });
+    });
+  });
+
   describe('build hook', function() {
     var plugin, context;
 
@@ -121,19 +154,18 @@ describe('build plugin', function() {
         config: {
           build: {
             buildEnv: 'development',
-            outputPath: 'tmp/dist-deploy',
+            distDir: 'tmp/dist-deploy'
           }
         }
       };
       plugin.beforeHook(context);
     });
 
-    it('builds the app and resolves with distDir and distFiles', function(done) {
+    it('builds the app and resolves with distFiles', function(done) {
       this.timeout(50000);
       return assert.isFulfilled(plugin.build(context))
         .then(function(result) {
           assert.deepEqual(result, {
-            distDir: 'tmp/dist-deploy',
             distFiles: [
                'assets/dummy.css',
                'assets/dummy.js',


### PR DESCRIPTION
Make it possible to change the distDir in an other plug-in like this:

```
      willDeploy: function(context) {
        var distDir = this.readConfig('distDir');
        return {
          distDir: distDir + path.sep + '_attachments'
        };
      },


``` 