### PR TITLE
Replace deprecated `ember-cli/ext/promise` with `rsvp`

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -13,11 +13,11 @@
 
 var EOL       = require('os').EOL;
 var multiline = require('multiline');
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP      = require('rsvp');
 var GitHubApi = require('github');
 
 var github         = new GitHubApi({version: '3.0.0'});
-var compareCommits = Promise.denodeify(github.repos.compareCommits);
+var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 var currentVersion = 'v' + require('../package').version;
 
 var user = 'ember-cli-deploy';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 var glob  = require('glob');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var path = require('path');
@@ -46,7 +46,7 @@ module.exports = {
           })
           .catch(function(error) {
             self.log('build failed', { color: 'red' });
-            return Promise.reject(error);
+            return RSVP.reject(error);
           });
       },
       _logSuccess: function(outputPath) {
@@ -60,7 +60,7 @@ module.exports = {
         }
         self.log('build ok', { verbose: true });
 
-        return Promise.resolve(files);
+        return RSVP.resolve(files);
       }
     });
     return new DeployPlugin();

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,8 +1,6 @@
 /*jshint globalstrict: true*/
 'use strict';
 
-var RSVP = require('ember-cli/lib/ext/promise');
-
 var assert  = require('ember-cli/tests/helpers/assert');
 
 describe('build plugin', function() {


### PR DESCRIPTION
## What Changed & Why
- Replaced deprecated `ember-cli/ext/promise` with `rsvp`. Ember CLI 2.12 Beta complains about this deprecation.
- Bumped Node version in CI configs to 4 because 0.12 was not happy with `const`s.