### PR TITLE
Option to reuse build output during plugin development

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ None
 
 * yarn test
 
+## Faster iteration while authoring deploy plugins & configs
+
+When you're working on a deploy plugin or tweaking your deploy config, you often run `ember deploy` repeatedly, and each run usually invokes this plugin to do a full rebuild of your app, even though your app has not changed and the build options are identical.
+
+You can instead reuse the build from the previous `ember deploy` by setting the environment variable `EMBER_CLI_DEPLOY_REUSE_BUILD`. This may make your interactive testing much faster. It's safe to use during development as long as you aren't actively changing your app or altering this module's `environment` or `outputPath`.
+
 ## Why `ember test` doesn't work
 
 Since this is a node-only ember-cli addon, we use mocha for testing and this package does not include many files and devDependencies which are part of ember-cli's typical `ember test` processes.

--- a/index.js
+++ b/index.js
@@ -20,6 +20,13 @@ module.exports = {
       build: function(/* context */) {
         var self       = this;
         var outputPath = this.readConfig('outputPath');
+        if (process.env.EMBER_CLI_DEPLOY_REUSE_BUILD) {
+          this.log('reusing build from `' + outputPath, { verbose: true });
+          return RSVP.resolve({
+            distDir: outputPath,
+            distFiles: glob.sync('**/*', { cwd: outputPath, nodir: true })
+          });
+        }
         var buildEnv   = this.readConfig('environment');
 
         var Builder  = this.project.require('ember-cli/lib/models/builder');

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   globals: {
     "describe": true,
     "beforeEach": true,
+    "afterEach": true,
     "it": true
   },
   env: {

--- a/tests/fixtures/fake-build-output/assets/inner-example.css
+++ b/tests/fixtures/fake-build-output/assets/inner-example.css
@@ -1,0 +1,1 @@
+/* hello world */

--- a/tests/fixtures/fake-build-output/top-file-example.js
+++ b/tests/fixtures/fake-build-output/top-file-example.js
@@ -1,0 +1,1 @@
+/* hello world */

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -135,11 +135,16 @@ describe('build plugin', function() {
           }
         }
       };
-      plugin.beforeHook(context);
     });
+
+    afterEach(function() {
+      delete process.env.EMBER_CLI_DEPLOY_REUSE_BUILD;
+    });
+
 
     it('builds the app and resolves with distDir and distFiles', function(done) {
       this.timeout(50000);
+      plugin.beforeHook(context);
       assert.isFulfilled(plugin.build(context))
         .then(function(result) {
           assert.deepEqual(result, {
@@ -167,5 +172,26 @@ describe('build plugin', function() {
           done(reason);
         });
     });
+
+    it('can reuse build results and resolve with distDir and distFiles', function(done) {
+      process.env.EMBER_CLI_DEPLOY_REUSE_BUILD = 'true';
+      context.config.build.outputPath = __dirname + '/fixtures/fake-build-output';
+      plugin.beforeHook(context);
+
+      assert.isFulfilled(plugin.build(context))
+        .then(function(result) {
+          assert.deepEqual(result, {
+            distDir: __dirname + '/fixtures/fake-build-output',
+            distFiles: [
+              'assets/inner-example.css',
+              'top-file-example.js'
+            ]
+          });
+          done();
+        }).catch(function(reason){
+          done(reason);
+        });
+    });
+
   });
 });


### PR DESCRIPTION
When you're working on a deploy plugin or tweaking your deploy config, you often run `ember deploy` repeatedly, and each run usually invokes this plugin to do a full rebuild of your app, even though your app has not changed and the build options are identical.

This PR makes it possible to set the environment variable EMBER_CLI_DEPLOY_REUSE_BUILD to reuse the results from the previous run. This can make it much faster to test changes to all the configuration and plugins that come after the build plugin (which is most of them).
