### PR TITLE
[BREAKING] include hidden files in distFiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
           this.log('reusing build from `' + outputPath, { verbose: true });
           return RSVP.resolve({
             distDir: outputPath,
-            distFiles: glob.sync('**/*', { cwd: outputPath, nodir: true })
+            distFiles: glob.sync('**/*', { cwd: outputPath, nodir: true , dot: true})
           });
         }
         var buildEnv   = this.readConfig('environment');
@@ -55,7 +55,7 @@ module.exports = {
       },
       _logSuccess: function(outputPath) {
         var self = this;
-        var files = glob.sync('**/**/*', { nonull: false, nodir: true, cwd: outputPath });
+        var files = glob.sync('**/**/*', { nonull: false, nodir: true, cwd: outputPath , dot: true});
 
         if (files && files.length) {
           files.forEach(function(path) {


### PR DESCRIPTION
- dot files are ignored from glob.sync , files like .htaccess would not get deployed since distFiles do not include hidden files. This commit configures glob.sync to include dot files.

It should be relatively rare that this breaking change affects developer's apps, but we are considering it breaking because it could result in dot files becoming part of your deploy pipeline that were excluded in previous versions