### PR TITLE
fix builder build undefined annotation

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,13 @@ module.exports = {
         });
 
         this.log('building app to `' + outputPath + '` using buildEnv `' + buildEnv + '`...', { verbose: true });
-        return builder.build()
+        let annotation = {
+          type: 'initial',
+          reason: 'build',
+          primaryFile: null,
+          changedFiles: [],
+        };
+        return builder.build(null, annotation)
           .finally(function() {
             return builder.cleanup();
           })


### PR DESCRIPTION
## What Changed & Why
Without this change, running `ember deploy production` in our ember 4 app throw the following error:
```
- build failed
TypeError: Cannot read properties of undefined (reading 'type')
TypeError: Cannot read properties of undefined (reading 'type')
    at Instrumentation._buildSummary (/.../frontend/node_modules/ember-cli/lib/models/instrumentation.js:131:32)
```

This is trying to fix the build error seeing when running `ember deploy production`.
Builder takes two more arguments:
https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/build.js#L25-L32

## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)